### PR TITLE
feat: ゼロ値許容の文字数バリデーション追加

### DIFF
--- a/src/lib/validation/string.go
+++ b/src/lib/validation/string.go
@@ -1,0 +1,24 @@
+package validation
+
+import (
+	"strconv"
+	"unicode/utf8"
+
+	"gopkg.in/go-playground/validator.v9"
+)
+
+// MinimumString ... 必要文字数を指定(ゼロ値許容)
+func MinimumString(fl validator.FieldLevel) bool {
+	min, err := strconv.Atoi(fl.Param())
+	if err != nil {
+		return false
+	}
+
+	keyword := fl.Field().String()
+	length := utf8.RuneCountInString(keyword)
+	if keyword == "" || min <= length {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
## Usage

```
// 構造体
type MyRequest struct {
  // ゼロ値もしくは、3文字以上の文字を許容する
  Keyword  string `validate:"minimum=3"`
}

// 処理
v := validator.New()
v.RegisterValidation("minimum", validation.MinimumString)
if err := v.Struct(param); err != nil {
  // do something
}
```
